### PR TITLE
refactor: grpc cleanup

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,25 +9,51 @@ import (
 	tx "github.com/cosmos/cosmos-sdk/api/cosmos/tx/v1beta1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/metadata"
 )
 
 // Client is a struct for querying transactions for a cosmos chain.
 type Client struct {
-	grpcEndpoint string
-	tls          bool
+	grpcEndpoint   string
+	tls            bool
+	headers        []string
+	grpcTimeout    time.Duration
+	grpcConnection *grpc.ClientConn
 }
 
-// NewClient returns a new Client instance.
-func NewClient(grpcEndpoint string, tls bool) Client {
-	return Client{
+// NewClient returns a new Client instance with an active gRPC connection.
+// Headers are passed as map of strings and translated to a key-value based array.
+func NewClient(
+	grpcEndpoint string,
+	tls bool,
+	headers map[string]string,
+	grpcTimeout time.Duration,
+) (Client, error) {
+	headersKV := make([]string, len(headers)*2)
+	index := 0
+	for key, value := range headers {
+		headersKV[index] = key
+		headersKV[index+1] = value
+		index = index + 2
+	}
+
+	c := Client{
 		grpcEndpoint: grpcEndpoint,
 		tls:          tls,
+		headers:      headersKV,
+		grpcTimeout:  grpcTimeout,
 	}
+	err := c.connectGRPC()
+	if err != nil {
+		return Client{}, err
+	}
+
+	return c, nil
 }
 
-// GetTxs returns the transactions which match the events queried,
-// e.g. ["message.action='/cosmos.bank.v1beta1.Msg/Send'"]
-func (c *Client) GetTxs(events []string) ([]*tx.Tx, error) {
+// connectGRPC dials up our grpc connection endpoint.
+func (c *Client) connectGRPC() error {
 	config := &tls.Config{
 		InsecureSkipVerify: false,
 	}
@@ -40,6 +66,7 @@ func (c *Client) GetTxs(events []string) ([]*tx.Tx, error) {
 		grpcOpts = []grpc.DialOption{
 			grpc.WithTransportCredentials(credentials.NewTLS(config)),
 			grpc.WithContextDialer(dial),
+			grpc.WithKeepaliveParams(keepalive.ClientParameters{}),
 		}
 	}
 
@@ -48,19 +75,24 @@ func (c *Client) GetTxs(events []string) ([]*tx.Tx, error) {
 		grpcOpts...,
 	)
 	if err != nil {
-		return []*tx.Tx{}, fmt.Errorf("failed to dial Cosmos gRPC service: %w", err)
+		return fmt.Errorf("failed to dial Cosmos gRPC service: %w", err)
 	}
 
-	defer grpcConn.Close()
-	queryClient := tx.NewServiceClient(grpcConn)
+	c.grpcConnection = grpcConn
+	return nil
+}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
+// GetTxs returns the transactions which match the events queried,
+// e.g. req.events=["message.action='/cosmos.bank.v1beta1.Msg/Send'"]
+func (c *Client) GetTxs(req *tx.GetTxsEventRequest) ([]*tx.Tx, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.grpcTimeout)
+	ctx = metadata.AppendToOutgoingContext(ctx, c.headers...)
 	defer cancel()
 
+	queryClient := tx.NewServiceClient(c.grpcConnection)
+
 	queryResponse, err := queryClient.GetTxsEvent(
-		ctx, &tx.GetTxsEventRequest{
-			Events: events,
-		},
+		ctx, req,
 	)
 	if err != nil {
 		return []*tx.Tx{}, fmt.Errorf("failed to make grpc query: %w", err)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Description

Small refactor of the grpc client to allow reuse of the grpc client, pass some timeout params, and allows for auth headers. 

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
