### PR TITLE
feat: add utility for converting denoms into ibc denoms

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/tendermint/tendermint/crypto/tmhash"
+)
+
+const (
+	ibcPrefix      = "ibc"
+	transferPrefix = "transfer"
+)
+
+func GetIBCDenom(channelID string, denom string) (string, error) {
+	if len(channelID) == 0 || len(denom) == 0 {
+		return "", fmt.Errorf("channel ID and denom cannot be empty")
+	}
+
+	hash := tmhash.New()
+	sourceStr := fmt.Sprintf("%s/%s/%s", transferPrefix, channelID, denom)
+
+	if _, err := hash.Write([]byte(sourceStr)); err != nil {
+		return "", err
+	}
+
+	bz := hash.Sum(nil)
+	hashString := strings.ToUpper(hex.EncodeToString(bz))
+
+	return fmt.Sprintf("%s/%s", ibcPrefix, hashString), nil
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetIBCDenom(t *testing.T) {
+	denom, err := GetIBCDenom("channel-0", "uatom")
+	require.NoError(t, err)
+	require.NotEmpty(t, denom)
+	require.Equal(
+		t,
+		"ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+		denom,
+	)
+
+	_, err = GetIBCDenom("", "")
+	require.Error(t, err)
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Description

Adds a required utility for converting assets into their IBC denoms, necessary for some of the osmosis queries

part of: #12

----

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added appropriate labels to the PR
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/umee-network/umee/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
